### PR TITLE
Added renderer attribute to output component.

### DIFF
--- a/extensions/inbox/rayo.xml
+++ b/extensions/inbox/rayo.xml
@@ -2144,6 +2144,13 @@
             <td>-1</td>
             <td>OPTIONAL</td>
           </tr>
+          <tr>
+            <td>renderer</td>
+            <td>Indicates which media engine the server should use to render the Output. The server defines the possible values and falls back to the platform default if not specified.</td>
+            <td>An arbitrary string</td>
+            <td></td>
+            <td>OPTIONAL</td>
+          </tr>
         </table>
 
         <section5 topic='Document Element' anchor='def-component-output-output-document'>
@@ -3314,6 +3321,13 @@
         <annotation>
           <documentation>
             Indicates the maximum amount of time for which the output should be allowed to run before being terminated. Includes repeats.
+          </documentation>
+        </annotation>
+      </attribute>
+      <attribute name="renderer" type="string" use="optional">
+        <annotation>
+          <documentation>
+            Indicates which media engine the server should use to render the Output.
           </documentation>
         </annotation>
       </attribute>


### PR DESCRIPTION
Indicates which media engine the server should use to render the Output. Optional, values are defined and enforced by the server implementation.
