### PR TITLE
[FEATURE] Allow repeat-times to be 0 for the output to repeat forever

### DIFF
--- a/extensions/inbox/rayo.xml
+++ b/extensions/inbox/rayo.xml
@@ -2322,7 +2322,7 @@
           <tr>
             <td>repeat-times</td>
             <td>Indicates the number of times the output should be played.</td>
-            <td>An integer greater than 0.</td>
+            <td>A positive integer or 0 to repeat forever.</td>
             <td>1</td>
             <td>OPTIONAL</td>
           </tr>
@@ -3593,7 +3593,7 @@
           </documentation>
         </annotation>
       </attribute>
-      <attribute name="repeat-times" type="positiveInteger" use="optional" default="1">
+      <attribute name="repeat-times" type="nonNegativeInteger" use="optional" default="1">
         <annotation>
           <documentation>
             Indicates the number of times the output should be played.


### PR DESCRIPTION
Implementing MOH would be easier if it were possible to specify that an output should be repeated forever. -1 seems like a conventional value for the purpose but this would require a new type to be defined. It would not make sense to repeat an output 0 times (and 1 is the default) so a value of 0 and a type of nonNegativeInteger seems to work.
