### PR TITLE
Optionally include platform-specific end reason codes

### DIFF
--- a/extensions/inbox/rayo.xml
+++ b/extensions/inbox/rayo.xml
@@ -1953,7 +1953,7 @@
           <th>Inclusion</th>
         </tr>
         <tr>
-          <td>code</td>
+          <td>platform_code</td>
           <td>A platform-specific end code. This could be a SIP code, ITU-T Q.850 or some other system. The code may be an arbitrary string.</td>
           <td>OPTIONAL</td>
         </tr>
@@ -3005,7 +3005,7 @@
   </element>
 
   <complexType name="endReasonType">
-    <attribute name="name" type="string" use="optional">
+    <attribute name="platform_code" type="string" use="optional">
       <annotation>
         <documentation>
           A platform-specific end code. This could be a SIP code, ITU-T Q.850 or some other system. The code may be an arbitrary string.

--- a/extensions/inbox/rayo.xml
+++ b/extensions/inbox/rayo.xml
@@ -1943,7 +1943,21 @@
     <p>The &lt;end/&gt; element has no attributes.</p>
 
     <section3 topic='End Reason Element' anchor='def-end-reason'>
-      <p>The following are valid end reason elements. Unless otherwise stated, they all MUST be empty, and they do not have any attributes.</p>
+      <p>The following are valid end reason elements. Unless otherwise stated, they all MUST be empty.</p>
+
+      <p>The attributes of the end reason element are as follows.</p>
+      <table caption='Attributes of End Reason Element'>
+        <tr>
+          <th>Attribute</th>
+          <th>Definition</th>
+          <th>Inclusion</th>
+        </tr>
+        <tr>
+          <td>code</td>
+          <td>A platform-specific end code. This could be a SIP code, ITU-T Q.850 or some other system. The code may be an arbitrary string.</td>
+          <td>OPTIONAL</td>
+        </tr>
+      </table>
 
       <dl>
         <di>
@@ -2990,6 +3004,16 @@
     </annotation>
   </element>
 
+  <complexType name="endReasonType">
+    <attribute name="name" type="string" use="optional">
+      <annotation>
+        <documentation>
+          A platform-specific end code. This could be a SIP code, ITU-T Q.850 or some other system. The code may be an arbitrary string.
+        </documentation>
+      </annotation>
+    </attribute>
+  </complexType>
+
   <!-- End Event -->
   <element name="end">
     <annotation>
@@ -3000,42 +3024,42 @@
     <complexType>
       <sequence>
         <choice>
-          <element name="hungup" type="tns:empty">
+          <element name="hungup" type="tns:endReasonType">
             <annotation>
               <documentation>
                 Indication that the call ended due to a normal hangup by the remote party.
               </documentation>
             </annotation>
           </element>
-          <element name="hangup-command" type="tns:empty">
+          <element name="hangup-command" type="tns:endReasonType">
             <annotation>
               <documentation>
                 Indication that the call ended due to a normal hangup triggered by a hangup command.
               </documentation>
             </annotation>
           </element>
-          <element name="timeout" type="tns:empty">
+          <element name="timeout" type="tns:endReasonType">
             <annotation>
               <documentation>
                 Indication that the call ended due to a timeout in contacting the remote party.
               </documentation>
             </annotation>
           </element>
-          <element name="busy" type="tns:empty">
+          <element name="busy" type="tns:endReasonType">
             <annotation>
               <documentation>
                 Indication that the call ended due to being rejected by the remote party subsequent to being accepted.
               </documentation>
             </annotation>
           </element>
-          <element name="rejected" type="tns:empty">
+          <element name="rejected" type="tns:endReasonType">
             <annotation>
               <documentation>
                 Indication that the call ended due to being rejected by the remote party before being accepted.
               </documentation>
             </annotation>
           </element>
-          <element name="error" type="tns:empty">
+          <element name="error" type="tns:endReasonType">
             <annotation>
               <documentation>
                 Indication that the call ended due to a system error.


### PR DESCRIPTION
Some applications require more detailed end reasons such as circuit congestion, etc. [Asterisk](http://www.voip-info.org/wiki/view/Asterisk+variable+hangupcause) and [FreeSWITCH](http://wiki.freeswitch.org/wiki/Hangup_causes) provide their own enumerations, while other platforms (eg PRISM) might expose SIP codes or something else entirely. This patch allows for passing those specific codes up to the Rayo client after categorisation as one of the more general Rayo end reasons.

@crienzo, @bklang and @loopingrage: I'd like your input on this, please.
