### PR TITLE
Use wav as default recording format

### DIFF
--- a/extensions/inbox/rayo.xml
+++ b/extensions/inbox/rayo.xml
@@ -1686,7 +1686,7 @@
           type='unavailable'>
   <complete xmlns='urn:xmpp:rayo:ext:1'>
     <stop xmlns='urn:xmpp:rayo:ext:complete:1'/>
-    <recording xmlns='urn:xmpp:rayo:record:complete:1' uri='xmpp:http://rayo.io/recordings/foo.mp3' duration='20000' size='12287492817'/>
+    <recording xmlns='urn:xmpp:rayo:record:complete:1' uri='xmpp:http://rayo.io/recordings/foo.wav' duration='20000' size='12287492817'/>
   </complete>
 </presence>
         ]]></example>
@@ -2656,7 +2656,7 @@
             <td>format</td>
             <td>File format used during recording.</td>
             <td>A valid format token, such as 'mp3', 'wav', 'h264'. Implementation specific.</td>
-            <td>mp3</td>
+            <td>wav</td>
             <td>OPTIONAL</td>
           </tr>
           <tr>
@@ -4037,7 +4037,7 @@
       </documentation>
     </annotation>
     <complexType>
-      <attribute name="format" type="token" use="optional" default="mp3">
+      <attribute name="format" type="token" use="optional" default="wav">
         <annotation>
           <documentation>
             File format used during recording.


### PR DESCRIPTION
Requiring a proprietary container like mp3 is evil for several reasons.

@bklang @emcgee @crienzo: Thoughts? I wonder if we should make the default platform specific?
