### PR TITLE
Map XMPP <message> to SIP MESSAGE?

### DIFF
--- a/extensions/inbox/rayo.xml
+++ b/extensions/inbox/rayo.xml
@@ -1877,6 +1877,35 @@
 </iq>
     ]]></example>
   </section2>
+
+  <section2 topic='Instant Messages' anchor='session-im'>
+    <section3 topic='Call-bound Messages' anchor='session-im-call-bound'>
+      <p>XMPP message stanzas directed to the call's JID with a type of 'normal' MAY be forwarded to the calling party by translating the message into the calling party's protocol. In the case of SIP, this SHOULD follow the conventions set out in <a href="http://tools.ietf.org/html/draft-ietf-stox-im-06">draft-ietf-stox-im-06</a> with the exception of the &lt;thread/&gt; to Call-ID mapping, as the Call-ID will always be that of the calling party.</p>
+
+      <p>If a message is directed to the call's JID with a type other than 'normal' then the server MUST return a &lt;feature-not-implemented/&gt; error with a type of 'modify'. If no translation is possible then the server SHOULD return the same error but with a type of 'cancel'.</p>
+
+      <example caption="Translation of a XMPP message into a SIP MESSAGE"><![CDATA[
+<message
+    from='juliet@capulet.lit/balcony'
+    to='9f00061@call.shakespeare.lit'
+    type='normal'>
+  <body>Art thou not Romeo, and a Montague?</body>
+</message>
+
+MESSAGE sip:romeo@montague.lit SIP/2.0
+Via: SIP/2.0/UDP call.shakespeare.lit;branch=AmRHlGRD0WD7BHgM5fKc
+Max-Forwards: 70
+From: <sip:call.shakespeare.lit>;tag=78aBN3CgAB8MK
+To: <sip:romeo@montague.lit>;tag=Z7nlVUbvTOmV6
+Call-ID: 2819297471
+CSeq: 55119460 MESSAGE
+Content-Type: text/plain
+Content-Length: 35
+
+Art thou not Romeo, and a Montague?
+      ]]></example>
+    </section3>
+  </section2>
 </section1>
 <section1 topic='Formal Definition' anchor='def'>
 


### PR DESCRIPTION
I was looking for a way to handle SIP INFO through Rayo. There don't seem to be any XEPs that are a good fit but it was mentioned that the regular XMPP <message> stanza could be used for SIP MESSAGE.

Most of Rayo is based around <iq> stanzas but I don't see why this can't be an exception. [RFC 6086](http://tools.ietf.org/html/rfc6086) says that a UA **SHOULD** send a response when receiving a SIP MESSAGE but there is no guarantee that a client actually will so perhaps the fire-and-forget nature of <message> is a good fit in this regard.

We could even take this one step further and forward any response sent using [XEP-0184](http://xmpp.org/extensions/xep-0184.html), Message Delivery Receipts.
