### PR TITLE
timers-started event

### DIFF
--- a/extensions/inbox/rayo.xml
+++ b/extensions/inbox/rayo.xml
@@ -1592,6 +1592,14 @@
 
       <section4 topic='Events' anchor='session-component-execution-prompt-events'>
         <p>The prompt component emits intermediate events from the nested output and input components.</p>
+        <p>It also emits an 'input-timers-started' event when the input component's timers are started, which corresponds to the completion of the output sub-component.</p>
+
+        <example caption='Prompt component announces that the input timers have started'><![CDATA[
+<presence from='9f00061@call.shakespeare.lit/eh3u28'
+          to='juliet@capulet.lit/courtyard'>
+  <input-timers-started xmlns='urn:xmpp:rayo:prompt:1'/>
+</presence>
+      ]]></example>
       </section4>
 
       <section4 topic='Completion' anchor='session-component-execution-prompt-completion'>
@@ -2634,6 +2642,12 @@
             <td>OPTIONAL</td>
           </tr>
         </table>
+      </section4>
+
+      <section4 topic='Input Timers Started Element' anchor='def-component-prompt-input-timers-started'>
+        <p>Indicates that the component's input timers have started.</p>
+        <p>The &lt;input-timers-started/&gt; element MUST be empty.</p>
+        <p>The &lt;input-timers-started/&gt; element has no attributes.</p>
       </section4>
     </section3>
 
@@ -4009,6 +4023,15 @@
         </sequence>
       </simpleContent>
     </complexType>
+  </element>
+
+  <!-- Input Timers Started Event -->
+  <element name="input-timers-started">
+    <annotation>
+      <documentation>
+        Indicates that the component's input timers have started.
+      </documentation>
+    </annotation>
   </element>
 
 </schema>


### PR DESCRIPTION
I am using Sippy Cup to test Adhearsion but I didn't want to rely on sleep to keep things in sync. I therefore used SIP messages as a signalling mechanism instead but still required an event to trigger these messages from. This event needed to fire when the input timers start, hence I created a timers-started event. You can see a working preliminary implementation of this at chewi/FreeSWITCH@f7c56ec4fd.

There was [some discussion](http://irclogger.com/.adhearsion/2014-01-10#1389372272) about exactly what conditions this should fire under and I want to get this cleared up before I start making changes to the spec.

It was suggested that it should only apply to prompt components when barge-in = false but this does not fit my use case. My prompts have barge-in = true but I still find the event useful because even though humans can barge in if they wish, I would rather have Sippy Cup wait until the prompt has completed as that is what humans are more likely to do for this particular service.

I don't believe the event should fire if the timers are to start immediately. This would always be the case for a bare input component as @crienzo says that such components either start their timers straight away or they never do.

The current code is supposed to effectively only fire the event from prompt components, irrespective of barge-in. This is how I think it should work. However, I just tested with barge-in = false, expecting it to work, and it didn't. Seemingly there is no internal start-timers command in this scenario, @crienzo?
