### PR TITLE
Add Recognition-Timeout as an Input attribute

### DIFF
--- a/extensions/xep-0327.xml
+++ b/extensions/xep-0327.xml
@@ -35,6 +35,12 @@
     <uri>http://voxeolabs.com</uri>
   </author>
   <revision>
+    <version>0.4</version>
+    <date>2014-08-22</date>
+    <initials>jad</initials>
+    <remark><p>Add Recognition-Timeout as an Input Element attribute.</p></remark>
+  </revision>
+  <revision>
     <version>0.3</version>
     <date>2014-01-30</date>
     <initials>bl</initials>
@@ -2619,6 +2625,13 @@ Art thou not Romeo, and a Montague?
             <td>Indicates the required response document format.</td>
             <td>Must support at least application/nlsml+xml, but may support others such as application/emma+xml.</td>
             <td>application/nlsml+xml</td>
+            <td>OPTIONAL</td>
+          </tr>
+          <tr>
+            <td>recognition-timeout</td>
+            <td>Indicates the time alloted to match speech input before sending a Recognition-Complete event and halting recognition.</td>
+            <td>Range from 0 to MAXTIMEOUT, where MAXTIMEOUT is platform specific</td>
+            <td>10</td>
             <td>OPTIONAL</td>
           </tr>
         </table>

--- a/extensions/xep-0327.xml
+++ b/extensions/xep-0327.xml
@@ -35,12 +35,6 @@
     <uri>http://voxeolabs.com</uri>
   </author>
   <revision>
-    <version>0.4</version>
-    <date>2014-08-22</date>
-    <initials>jad</initials>
-    <remark><p>Add Recognition-Timeout as an Input Element attribute.</p></remark>
-  </revision>
-  <revision>
     <version>0.3</version>
     <date>2014-01-30</date>
     <initials>bl</initials>
@@ -2600,6 +2594,13 @@ Art thou not Romeo, and a Montague?
             <td>OPTIONAL</td>
           </tr>
           <tr>
+            <td>recognition-timeout</td>
+            <td>Indicates the time (in seconds) alloted to match speech input before triggering a Nomatch completion.</td>
+            <td>Integer value from 0 to MAXTIMEOUT, where MAXTIMEOUT is implementation specific, or -1 to disable.</td>
+            <td>-1</td>
+            <td>OPTIONAL</td>
+          </tr>
+          <tr>
             <td>sensitivity</td>
             <td>Indicates how sensitive the interpreter should be to loud versus quiet input. Higher values represent greater sensitivity.</td>
             <td>A decimal value between 0 and 1.</td>
@@ -2625,13 +2626,6 @@ Art thou not Romeo, and a Montague?
             <td>Indicates the required response document format.</td>
             <td>Must support at least application/nlsml+xml, but may support others such as application/emma+xml.</td>
             <td>application/nlsml+xml</td>
-            <td>OPTIONAL</td>
-          </tr>
-          <tr>
-            <td>recognition-timeout</td>
-            <td>Indicates the time alloted to match speech input before sending a Recognition-Complete event and halting recognition.</td>
-            <td>Range from 0 to MAXTIMEOUT, where MAXTIMEOUT is platform specific</td>
-            <td>10</td>
             <td>OPTIONAL</td>
           </tr>
         </table>
@@ -3955,6 +3949,13 @@ Art thou not Romeo, and a Montague?
           <annotation>
             <documentation>
               Indicates (in the case of DTMF input) the amount of time between input digits which may expire before a timeout is triggered.
+            </documentation>
+          </annotation>
+        </attribute>
+        <attribute name="recognition-timeout" type="core:timeoutType" use="optional" default="-1">
+          <annotation>
+            <documentation>
+              Indicates the time (in seconds) alloted to match speech input before triggering a Nomatch completion.
             </documentation>
           </annotation>
         </attribute>

--- a/extensions/xep-0327.xml
+++ b/extensions/xep-0327.xml
@@ -2595,7 +2595,7 @@ Art thou not Romeo, and a Montague?
           </tr>
           <tr>
             <td>recognition-timeout</td>
-            <td>Indicates the time (in seconds) alloted to match speech input before triggering a Nomatch completion.</td>
+            <td>Indicates the time (in milliseconds) alloted to match speech input before triggering a Nomatch completion.</td>
             <td>Integer value from 0 to MAXTIMEOUT, where MAXTIMEOUT is implementation specific, or -1 to disable.</td>
             <td>-1</td>
             <td>OPTIONAL</td>
@@ -3955,7 +3955,7 @@ Art thou not Romeo, and a Montague?
         <attribute name="recognition-timeout" type="core:timeoutType" use="optional" default="-1">
           <annotation>
             <documentation>
-              Indicates the time (in seconds) alloted to match speech input before triggering a Nomatch completion.
+              Indicates the time (in milliseconds) alloted to match speech input before triggering a Nomatch completion.
             </documentation>
           </annotation>
         </attribute>

--- a/extensions/xep-0327.xml
+++ b/extensions/xep-0327.xml
@@ -2595,7 +2595,7 @@ Art thou not Romeo, and a Montague?
           </tr>
           <tr>
             <td>recognition-timeout</td>
-            <td>Indicates the time (in milliseconds) alloted to match speech input before triggering a Nomatch completion.</td>
+            <td>Indicates the time (in milliseconds) for speech input, after speech has begun, to return a Match before triggering a Nomatch completion.</td>
             <td>Integer value from 0 to MAXTIMEOUT, where MAXTIMEOUT is implementation specific, or -1 to disable.</td>
             <td>-1</td>
             <td>OPTIONAL</td>
@@ -3955,7 +3955,7 @@ Art thou not Romeo, and a Montague?
         <attribute name="recognition-timeout" type="core:timeoutType" use="optional" default="-1">
           <annotation>
             <documentation>
-              Indicates the time (in milliseconds) alloted to match speech input before triggering a Nomatch completion.
+              Indicates the time (in milliseconds) for speech input, after speech has begun, to return a Match before triggering a Nomatch completion.
             </documentation>
           </annotation>
         </attribute>


### PR DESCRIPTION
Update to Rayo protocol to add support for `Recognition-Timeout` MRCP header in support of [Punchblock Pull Request 228 ](https://github.com/adhearsion/punchblock/pull/228).
