### PR TITLE
add dtmf-term-timeout and speech-complete-timeout

### DIFF
--- a/extensions/xep-0327.xml
+++ b/extensions/xep-0327.xml
@@ -2607,6 +2607,20 @@ Art thou not Romeo, and a Montague?
             <td>OPTIONAL</td>
           </tr>
           <tr>
+            <td>speech-complete-timeout</td>
+            <td>Indicates the time alloted to continue accepting speech input after a match has been found before finalizing recognition.</td>
+            <td>A positive integer in milliseconds, before finalizing recognition. or -1 to disable.</td>
+            <td>-1</td>
+            <td>OPTIONAL</td>
+          </tr>
+          <tr>
+            <td>dtmf-term-timeout</td>
+            <td>Indicates the time alloted to continue accepting dtmf input after a match has been found before finalizing recognition.</td>
+            <td>Integer value from 0 to MAXTIMEOUT, or -1 to disable.</td>
+            <td>-1</td>
+            <td>OPTIONAL</td>
+          </tr>
+          <tr>
             <td>sensitivity</td>
             <td>Indicates how sensitive the interpreter should be to loud versus quiet input. Higher values represent greater sensitivity.</td>
             <td>A decimal value between 0 and 1.</td>
@@ -3962,6 +3976,20 @@ Art thou not Romeo, and a Montague?
           <annotation>
             <documentation>
               Indicates the time (in milliseconds) for speech input, after speech has begun, to return a Match before triggering a Nomatch completion.
+            </documentation>
+          </annotation>
+        </attribute>
+        <attribute name="speech-complete-timeout" type="core:timeoutType" use="optional" default="-1">
+          <annotation>
+            <documentation>
+              Indicates the time alloted to continue accepting speech input after a match has been found before finalizing recognition.
+            </documentation>
+          </annotation>
+        </attribute>
+        <attribute name="dtmf-term-timeout" type="core:timeoutType" use="optional" default="-1">
+          <annotation>
+            <documentation>
+              Indicates the time alloted to continue accepting dtmf input after a match has been found before finalizing recognition.
             </documentation>
           </annotation>
         </attribute>


### PR DESCRIPTION
allows for more fine-tuned settings on ASR input

_squashed commits follow_

Add Recognition-Timeout as an Input attribute

update with suggested edits

specify recognition-timeout in milliseconds

tweak description of recognition-timeout
